### PR TITLE
Add Bitcoin Core RPC ChainDataSource (feature="rpc")

### DIFF
--- a/src/bitcoin_core_chain.rs
+++ b/src/bitcoin_core_chain.rs
@@ -1,0 +1,126 @@
+use crate::utxo_scoring::UtxoEntry;
+use crate::velocity_analyzer::{ChainDataSource, TxActivity, VelocityError};
+use bitcoin::util::amount::Amount;
+use bitcoin::Address;
+use bitcoincore_rpc::json::{ListSinceBlockCategory, ScanTxOutRequest};
+use bitcoincore_rpc::{Client, RpcApi};
+use std::collections::HashSet;
+use std::str::FromStr;
+
+/// Bitcoin Core-backed chain data source.
+#[derive(Debug, Clone)]
+pub struct BitcoinCoreChainDataSource {
+    client: Client,
+}
+
+impl BitcoinCoreChainDataSource {
+    pub fn new(client: Client) -> Self {
+        Self { client }
+    }
+
+    fn parse_addresses(&self, addresses: &[String]) -> Result<Vec<Address>, VelocityError> {
+        addresses
+            .iter()
+            .map(|addr| {
+                Address::from_str(addr).map_err(|e| {
+                    VelocityError::InvalidData(format!("invalid address {addr}: {e}"))
+                })
+            })
+            .collect()
+    }
+
+    fn map_rpc_error<E: std::fmt::Display>(error: E) -> VelocityError {
+        VelocityError::DataSource(error.to_string())
+    }
+}
+
+impl ChainDataSource for BitcoinCoreChainDataSource {
+    fn utxos_for_addresses(&self, addresses: &[String]) -> Result<Vec<UtxoEntry>, VelocityError> {
+        let parsed_addresses = self.parse_addresses(addresses)?;
+        let scan_objects: Vec<ScanTxOutRequest> = parsed_addresses
+            .into_iter()
+            .map(ScanTxOutRequest::Addr)
+            .collect();
+
+        let scan_result = self
+            .client
+            .scan_tx_out_set_blocking(&scan_objects)
+            .map_err(Self::map_rpc_error)?;
+
+        let utxos = scan_result
+            .unspents
+            .into_iter()
+            .map(|unspent| UtxoEntry {
+                txid: unspent.txid,
+                vout: unspent.vout,
+                amount: unspent.amount,
+                height: unspent.height,
+            })
+            .collect();
+
+        Ok(utxos)
+    }
+
+    fn outgoing_activity_for_addresses(
+        &self,
+        addresses: &[String],
+        start_height: u64,
+        end_height: u64,
+    ) -> Result<TxActivity, VelocityError> {
+        let address_set: HashSet<String> =
+            addresses.iter().map(|address| address.to_string()).collect();
+
+        let start_hash = if start_height == 0 {
+            None
+        } else {
+            Some(
+                self.client
+                    .get_block_hash(start_height.saturating_sub(1))
+                    .map_err(Self::map_rpc_error)?,
+            )
+        };
+
+        let list_result = self
+            .client
+            .list_since_block(
+                start_hash.as_ref(),
+                None,
+                Some(true),
+                Some(true),
+            )
+            .map_err(Self::map_rpc_error)?;
+
+        let mut count_outgoing: u32 = 0;
+        let mut outgoing_sats: u64 = 0;
+
+        for tx in list_result.transactions {
+            if tx.category != ListSinceBlockCategory::Send {
+                continue;
+            }
+
+            let address_matches = tx
+                .address
+                .as_ref()
+                .map(|addr| address_set.contains(&addr.to_string()))
+                .unwrap_or(false);
+
+            if !address_matches {
+                continue;
+            }
+
+            if let Some(block_height) = tx.blockheight {
+                if block_height < start_height || block_height > end_height {
+                    continue;
+                }
+            }
+
+            count_outgoing = count_outgoing.saturating_add(1);
+            outgoing_sats = outgoing_sats.saturating_add(tx.amount.to_sat());
+        }
+
+        Ok(TxActivity {
+            count_outgoing,
+            volume_outgoing: Amount::from_sat(outgoing_sats),
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,11 @@
 pub mod alerts;
 pub mod economic_oracle;
 pub mod rbi_engine;
+pub mod utxo_scoring;
+pub mod velocity_analyzer;
+pub mod velocity_config;
+
+#[cfg(feature = "rpc")]
+pub mod bitcoin_core_chain;
 
 pub mod prelude;


### PR DESCRIPTION
### Motivation
- Provide a production-ready `ChainDataSource` implementation that uses Bitcoin Core RPC to fetch UTXOs and outgoing activity. 
- Prefer `scantxoutset` for UTXO discovery and `listsinceblock` for outgoing transaction detection to rely on Bitcoin Core wallet/indexer behavior. 
- Surface errors as the typed `VelocityError` and avoid panics/`unwrap` so callers can handle failures robustly.

### Description
- Add `BitcoinCoreChainDataSource` backed by the `bitcoincore-rpc` `Client` with a constructor `BitcoinCoreChainDataSource::new`. 
- Implement `utxos_for_addresses` using `scan_tx_out_set_blocking` (scantxoutset) and convert RPC `unspents` into `UtxoEntry` values. 
- Implement `outgoing_activity_for_addresses` using `list_since_block` (with an optional start block hash) and count `Send` transactions scoped to the provided address list and height window. 
- Parse address strings with `Address::from_str`, map RPC/displayable errors to `VelocityError::DataSource`, and gate the module behind the `rpc` feature by exporting it in `lib.rs` under `#[cfg(feature = "rpc")]`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698548e9716883328a69e746bb32159e)