### PR TITLE
Use `bitcoin::Amount` (v0.30) imports and add optional `rpc` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,6 @@ rusqlite = { version = "0.30", features = ["bundled"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4"
+
+[features]
+rpc = []

--- a/src/simulation/step.rs
+++ b/src/simulation/step.rs
@@ -8,7 +8,7 @@ use crate::velocity_analyzer::{
     ChainDataSource, ParticipantRegistry, TxActivity, VelocityAnalyzer, VelocityError,
 };
 use crate::velocity_config::VelocityConfig;
-use bitcoin::util::amount::Amount;
+use bitcoin::Amount;
 use chrono::TimeZone;
 use rust_decimal::prelude::ToPrimitive;
 use std::collections::{BTreeMap, HashMap};

--- a/src/utxo_scoring.rs
+++ b/src/utxo_scoring.rs
@@ -1,4 +1,4 @@
-use bitcoin::util::amount::Amount;
+use bitcoin::Amount;
 use bitcoin::Txid;
 
 /// Basic UTXO entry needed for freshness computations.

--- a/src/velocity_analyzer.rs
+++ b/src/velocity_analyzer.rs
@@ -1,6 +1,6 @@
 use crate::utxo_scoring::{utxo_freshness_score, weighted_utxo_age_days, UtxoEntry};
 use crate::velocity_config::VelocityConfig;
-use bitcoin::util::amount::Amount;
+use bitcoin::Amount;
 use rust_decimal::Decimal;
 use std::collections::HashMap;
 


### PR DESCRIPTION
### Motivation
- Fix unresolved import `bitcoin::util::amount::Amount` when compiling against `bitcoin` crate v0.30.x. 
- Preserve existing behavior while updating imports to match the current `bitcoin` crate API. 
- Silence the `#[cfg(feature = "rpc")] unexpected cfg condition` warning by declaring an optional feature. 

### Description
- Replaced `use bitcoin::util::amount::Amount;` with `use bitcoin::Amount;` in `src/simulation/step.rs`, `src/utxo_scoring.rs`, and `src/velocity_analyzer.rs`. 
- Added an optional `rpc` feature to `Cargo.toml` (`[features]
rpc = []`) to match the `#[cfg(feature = "rpc")]` conditional in `src/lib.rs` without changing runtime behavior. 
- Preserved all business logic, numeric behavior, and public APIs; no additional dependencies were added. 

### Testing
- No automated tests or builds were executed as part of this change. 
- Existing unit tests in the repository were left unchanged and can be run with `cargo test` to validate behavior locally or in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988fc0b7a6883328b2d5f4216949f0b)