### PR TITLE
Enforce minimum demand shock threshold for health checks

### DIFF
--- a/src/rbi_engine.rs
+++ b/src/rbi_engine.rs
@@ -5,6 +5,8 @@ use chrono::{DateTime, Utc};
 use rust_decimal::prelude::ToPrimitive;
 use serde::Serialize;
 
+const MIN_DEMAND_THRESHOLD: f64 = 1e-9;
+
 #[derive(Debug, Clone)]
 pub struct ParticipantSnapshot {
     pub participant_id: String,
@@ -180,7 +182,7 @@ impl<P: EconomicDataProvider> RBIEngine<P> {
             return Err(RBIError::InvalidState("t_c must be finite and > 0".into()));
         }
 
-        if d_s.abs() < f64::EPSILON {
+        if d_s.abs() < MIN_DEMAND_THRESHOLD {
             let snapshot = RBISnapshot {
                 timestamp,
                 block_height: current_height,


### PR DESCRIPTION
### Motivation
- Ensure near-zero demand shock is classified as indeterminate/unhealthy (stagnation, not health) by introducing a deterministic, explicit threshold; no skills were required for this change.

### Description
- Add `const MIN_DEMAND_THRESHOLD: f64 = 1e-9` to `src/rbi_engine.rs` and replace the `d_s.abs() < f64::EPSILON` check with `d_s.abs() < MIN_DEMAND_THRESHOLD` so very small demand shocks short-circuit to `Indeterminate`/unhealthy before RBI computation while preserving deterministic numeric semantics.

### Testing
- Ran `cargo test --locked --all` and all automated tests passed, including the simulation determinism suite and the failing `demand_shock_near_zero_not_healthy` invariant.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988fd4f1d4483329c0f0fdf28ad769b)